### PR TITLE
Update "get brew status" endpoint to return a new message, when its over 30 degrees celsius

### DIFF
--- a/RTech.CoffeeMachine.Api.Tests/BrewCoffee/Controllers/CoffeeMachineControllerTests.cs
+++ b/RTech.CoffeeMachine.Api.Tests/BrewCoffee/Controllers/CoffeeMachineControllerTests.cs
@@ -135,6 +135,30 @@ public class CoffeeMachineControllerTests : IClassFixture<WebApplicationFactory<
         content.Prepared.ShouldBe(expectedPrepared);
     }
 
+    [Fact]
+    public async Task GetBrewStatus_WhenTemperatureRequestThrowsException_ShouldReturn502()
+    {
+        false.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetBrewStatus_WhenTemperatureRequestReturns500_ShouldReturn502()
+    {
+        false.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetBrewStatus_WhenTemperatureAbove30Degrees_ShouldReturnIcedCoffee()
+    {
+        false.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetBrewStatus_WhenTemperatureBelow31Degrees_ShouldReturnHotCoffee()
+    {
+        false.ShouldBeTrue();
+    }
+
     private Task<HttpResponseMessage> GetEndpointResponse(Action<IServiceCollection> servicesConfiguration)
     {
         var mockFactory = _factory.WithWebHostBuilder(builder =>

--- a/RTech.CoffeeMachine.Api.Tests/BrewCoffee/Controllers/CoffeeMachineControllerTests.cs
+++ b/RTech.CoffeeMachine.Api.Tests/BrewCoffee/Controllers/CoffeeMachineControllerTests.cs
@@ -1,17 +1,23 @@
 ﻿using System.Net;
+using System.Net.Mime;
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Caching.Memory;
 using Moq;
-using RTech.CoffeeMachine.Api.BrewCoffee.Controllers;
+using RichardSzalay.MockHttp;
+using RTech.CoffeeMachine.Api.BrewCoffee.Filters;
 using RTech.CoffeeMachine.Api.BrewCoffee.Models;
 using RTech.CoffeeMachine.Api.BrewCoffee.Util;
 using Shouldly;
+using static RTech.CoffeeMachine.Api.BrewCoffee.Models.TemperatureResponse;
 
 namespace RTech.CoffeeMachine.Api.Tests.BrewCoffee.Controllers;
 
 public class CoffeeMachineControllerTests : IClassFixture<WebApplicationFactory<Program>>
 {
+    private const string MOCKED_HTTPCLIENT_BASE_URL = "https://a.com";
+    private const string BREW_READY_HOT_MESSAGE = "Your piping hot coffee is ready";
     private readonly WebApplicationFactory<Program> _factory;
 
     public CoffeeMachineControllerTests(WebApplicationFactory<Program> factory)
@@ -24,12 +30,9 @@ public class CoffeeMachineControllerTests : IClassFixture<WebApplicationFactory<
     {
         var brewStatusProvider = new Mock<IBrewStatusProvider>();
         brewStatusProvider.Setup(p => p.GetBrewStatus())
-            .Returns(BrewStatus.None);
+            .ReturnsAsync(BrewStatus.None);
 
-        var response = await GetEndpointResponse(services =>
-        {
-            services.AddSingleton<IBrewStatusProvider>(brewStatusProvider.Object);
-        });
+        var response = await GetEndpointResponse(brewStatusProvider: brewStatusProvider.Object);
 
         response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
         var content = await response.Content.ReadAsStringAsync();
@@ -43,10 +46,7 @@ public class CoffeeMachineControllerTests : IClassFixture<WebApplicationFactory<
         dateTimeProvider.Setup(p => p.GetLocalNow())
             .Throws<InvalidOperationException>();
 
-        var response = await GetEndpointResponse(services =>
-        {
-            services.AddSingleton<IDateTimeProvider>(dateTimeProvider.Object);
-        });
+        var response = await GetEndpointResponse(dateTimeProvider: dateTimeProvider.Object);
 
         response.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
         var content = await response.Content.ReadAsStringAsync();
@@ -58,11 +58,8 @@ public class CoffeeMachineControllerTests : IClassFixture<WebApplicationFactory<
     {
         var cache = new MemoryCache(new MemoryCacheOptions());
         long numRequestsSoFar = 4;
-        cache.Set(CoffeeMachineController.CACHE_KEY_NUM_REQUESTS, numRequestsSoFar);
-        var response = await GetEndpointResponse(services =>
-        {
-            services.AddSingleton<IMemoryCache>(cache);
-        });
+        cache.Set(BrewStatusUnavailableFilter.CACHE_KEY_NUM_REQUESTS, numRequestsSoFar);
+        var response = await GetEndpointResponse(cache: cache);
 
         response.StatusCode.ShouldBe(HttpStatusCode.ServiceUnavailable);
         var content = await response.Content.ReadAsStringAsync();
@@ -79,11 +76,8 @@ public class CoffeeMachineControllerTests : IClassFixture<WebApplicationFactory<
     public async Task GetBrewStatus_WhenEndpointCalled_ShouldReturnCorrectStatusCode(long numRequestsSoFar, int expectedStatusCode)
     {
         var cache = new MemoryCache(new MemoryCacheOptions());
-        cache.Set(CoffeeMachineController.CACHE_KEY_NUM_REQUESTS, numRequestsSoFar);
-        var response = await GetEndpointResponse(services =>
-        {
-            services.AddSingleton<IMemoryCache>(cache);
-        });
+        cache.Set(BrewStatusUnavailableFilter.CACHE_KEY_NUM_REQUESTS, numRequestsSoFar);
+        var response = await GetEndpointResponse(cache: cache);
 
         response.ShouldNotBeNull();
         ((int)response.StatusCode).ShouldBe(expectedStatusCode);
@@ -95,17 +89,16 @@ public class CoffeeMachineControllerTests : IClassFixture<WebApplicationFactory<
     public async Task GetBrewStatus_WhenApril1st_ShouldReturnEmpty418(long numRequestsSoFar)
     {
         var cache = new MemoryCache(new MemoryCacheOptions());
-        cache.Set(CoffeeMachineController.CACHE_KEY_NUM_REQUESTS, numRequestsSoFar);
+        cache.Set(BrewStatusUnavailableFilter.CACHE_KEY_NUM_REQUESTS, numRequestsSoFar);
 
         var dateTimeProvider = new Mock<IDateTimeProvider>();
         dateTimeProvider.Setup(p => p.GetLocalNow())
             .Returns(new DateTime(2023, 4, 1));
 
-        var response = await GetEndpointResponse(services =>
-        {
-            services.AddSingleton<IMemoryCache>(cache);
-            services.AddSingleton<IDateTimeProvider>(dateTimeProvider.Object);
-        });
+        var response = await GetEndpointResponse(
+            cache: cache,
+            dateTimeProvider: dateTimeProvider.Object
+        );
 
         ((int)response.StatusCode).ShouldBe(StatusCodes.Status418ImATeapot);
         var content = await response.Content.ReadAsStringAsync();
@@ -120,15 +113,12 @@ public class CoffeeMachineControllerTests : IClassFixture<WebApplicationFactory<
         dateTimeProvider.Setup(p => p.GetLocalNow())
             .Returns(nowLocal);
 
-        var response = await GetEndpointResponse(services =>
-        {
-            services.AddSingleton<IDateTimeProvider>(dateTimeProvider.Object);
-        });
+        var response = await GetEndpointResponse(dateTimeProvider: dateTimeProvider.Object);
 
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
         var content = await response.Content.ReadFromJsonAsync<BrewStatusResponse>();
         content.ShouldNotBeNull();
-        content.Message.ShouldBe("Your piping hot coffee is ready");
+        content.Message.ShouldBe(BREW_READY_HOT_MESSAGE);
 
         var offsetStr = DateTime.Now.ToString("zzz").Replace(":", "");
         var expectedPrepared = $"2023-01-02T03:04:05{offsetStr}";
@@ -138,35 +128,95 @@ public class CoffeeMachineControllerTests : IClassFixture<WebApplicationFactory<
     [Fact]
     public async Task GetBrewStatus_WhenTemperatureRequestThrowsException_ShouldReturn502()
     {
-        false.ShouldBeTrue();
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When("*")
+            .Throw(new HttpRequestException());
+
+        var httpClient = mockHttp.ToHttpClient();
+        httpClient.BaseAddress = new Uri(MOCKED_HTTPCLIENT_BASE_URL);
+        var response = await GetEndpointResponse(httpClient: httpClient);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadGateway);
+        var content = await response.Content.ReadAsStringAsync();
+        content.ShouldBe(string.Empty);
     }
 
     [Fact]
     public async Task GetBrewStatus_WhenTemperatureRequestReturns500_ShouldReturn502()
     {
-        false.ShouldBeTrue();
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When("*")
+            .Respond(HttpStatusCode.InternalServerError);
+
+        var httpClient = mockHttp.ToHttpClient();
+        httpClient.BaseAddress = new Uri(MOCKED_HTTPCLIENT_BASE_URL);
+        var response = await GetEndpointResponse(httpClient: httpClient);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.BadGateway);
+        var content = await response.Content.ReadAsStringAsync();
+        content.ShouldBe(string.Empty);
     }
 
-    [Fact]
-    public async Task GetBrewStatus_WhenTemperatureAbove30Degrees_ShouldReturnIcedCoffee()
+    [Theory]
+    [InlineData(30, BREW_READY_HOT_MESSAGE)]
+    [InlineData(30.01, "Your refreshing iced coffee is ready")]
+    public async Task GetBrewStatus_WhenTemperatureRetrieved_ShouldReturnCorrectMessage(float temperature, string expectedMessage)
     {
-        false.ShouldBeTrue();
+        var httpClient = CreateMockedHttpClient(temperature);
+        var response = await GetEndpointResponse(httpClient: httpClient);
+
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        var content = await response.Content.ReadFromJsonAsync<BrewStatusResponse>();
+        content.ShouldNotBeNull();
+        content.Message.ShouldBe(expectedMessage);
     }
 
-    [Fact]
-    public async Task GetBrewStatus_WhenTemperatureBelow31Degrees_ShouldReturnHotCoffee()
-    {
-        false.ShouldBeTrue();
-    }
-
-    private Task<HttpResponseMessage> GetEndpointResponse(Action<IServiceCollection> servicesConfiguration)
+    private Task<HttpResponseMessage> GetEndpointResponse(
+        IDateTimeProvider? dateTimeProvider = null,
+        IBrewStatusProvider? brewStatusProvider = null,
+        IMemoryCache? cache = null,
+        HttpClient? httpClient = null
+    )
     {
         var mockFactory = _factory.WithWebHostBuilder(builder =>
         {
-            builder.ConfigureTestServices(servicesConfiguration);
+            builder.ConfigureTestServices(services =>
+            {
+                if (dateTimeProvider != null)
+                    services.AddSingleton<IDateTimeProvider>(dateTimeProvider);
+                if (brewStatusProvider != null)
+                    services.AddSingleton<IBrewStatusProvider>(brewStatusProvider);
+                if (cache != null)
+                    services.AddSingleton<IMemoryCache>(cache);
+
+                httpClient ??= CreateMockedHttpClient(30);
+                services.AddHttpClient<IWeatherProxy, WeatherProxy>(client => new WeatherProxy(
+                    Mock.Of<ILogger<WeatherProxy>>(),
+                    httpClient
+                ));
+            });
         });
 
         var client = mockFactory.CreateClient();
         return client.GetAsync("brew-coffee");
+    }
+
+    private static HttpClient CreateMockedHttpClient(float temperature)
+    {
+        var responseJson = JsonSerializer.Serialize(new TemperatureResponse
+        {
+            Weather = new CurrentWeather
+            {
+                Temperature = temperature
+            }
+        });
+
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.When("*")
+            .Respond(MediaTypeNames.Application.Json, responseJson);
+
+        var httpClient = mockHttp.ToHttpClient();
+        httpClient.BaseAddress = new Uri(MOCKED_HTTPCLIENT_BASE_URL);  // URL not actually called, just needs a base address
+        return httpClient;
     }
 }

--- a/RTech.CoffeeMachine.Api.Tests/RTech.CoffeeMachine.Api.Tests.csproj
+++ b/RTech.CoffeeMachine.Api.Tests/RTech.CoffeeMachine.Api.Tests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Shouldly" Version="4.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -31,6 +32,7 @@
     <None Remove="BrewCoffee\" />
     <None Remove="BrewCoffee\Controllers\" />
     <None Remove="Moq" />
+    <None Remove="RichardSzalay.MockHttp" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="BrewCoffee\" />

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Controllers/CoffeeMachineController.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Controllers/CoffeeMachineController.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Caching.Memory;
+using RTech.CoffeeMachine.Api.BrewCoffee.Filters;
 using RTech.CoffeeMachine.Api.BrewCoffee.Models;
 using RTech.CoffeeMachine.Api.BrewCoffee.Util;
 
@@ -12,53 +12,47 @@ public class CoffeeMachineController : ControllerBase
     private readonly ILogger<CoffeeMachineController> _logger;
     private readonly IDateTimeProvider _dateTimeProvider;
     private readonly IBrewStatusProvider _brewStatusProvider;
-    // Interviewer note: MemoryCache from Microsoft.Extensions.Caching.Abstractions is thread safe
-    private readonly IMemoryCache _cache;
-    public static readonly string CACHE_KEY_NUM_REQUESTS = $"{nameof(CoffeeMachineController)}:numRequests";
 
     public CoffeeMachineController(
         ILogger<CoffeeMachineController> logger,
         IDateTimeProvider dateTimeProvider,
-        IBrewStatusProvider brewStatusProvider,
-        IMemoryCache cache
+        IBrewStatusProvider brewStatusProvider
     )
     {
         _logger = logger;
         _dateTimeProvider = dateTimeProvider;
         _brewStatusProvider = brewStatusProvider;
-        _cache = cache;
-
-        if (!_cache.TryGetValue<long>(CACHE_KEY_NUM_REQUESTS, out var _))
-        {
-            _cache.Set<long>(CACHE_KEY_NUM_REQUESTS, 0);
-        }
     }
 
+    [ServiceFilter(typeof(TeapotFilter))]
+    [ServiceFilter(typeof(BrewStatusUnavailableFilter))]
     [HttpGet("brew-coffee")]
-    public IActionResult GetBrewStatus()
+    public async Task<IActionResult> GetBrewStatus()
     {
-        // Interviewer note: I'm assuming that the april fools check uses local time (operating system time)
-        var localNow = _dateTimeProvider.GetLocalNow();
-        var isApril1st = localNow.Month == 4 && localNow.Day == 1;
-        if (isApril1st)
+        BrewStatus status;
+        try
         {
-            return StatusCode(StatusCodes.Status418ImATeapot, null);
+            status = await _brewStatusProvider.GetBrewStatus();
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve brew status");
+            return StatusCode(StatusCodes.Status502BadGateway, null);
+        }
+        catch (Exception)
+        {
+            throw;
         }
 
-        // Interviewer note: I'm assuming that on april 1st, every 5th request still returns 418
-        var numRequests = _cache.Get<long>(CACHE_KEY_NUM_REQUESTS);
-        numRequests++;
-        _cache.Set(CACHE_KEY_NUM_REQUESTS, numRequests);
-        if (numRequests % 5 == 0)
+        if (status == BrewStatus.ReadyHot)
         {
-            return StatusCode(StatusCodes.Status503ServiceUnavailable, null);
-        }
-
-        var status = _brewStatusProvider.GetBrewStatus();
-        if (status == BrewStatus.Ready)
-        {
-            var prepared = GetPreparedTimestamp(localNow);
+            var prepared = GetPreparedTimestamp(_dateTimeProvider.GetLocalNow());
             return Ok(new BrewStatusResponse("Your piping hot coffee is ready", prepared));
+        }
+        else if (status == BrewStatus.ReadyIced)
+        {
+            var prepared = GetPreparedTimestamp(_dateTimeProvider.GetLocalNow());
+            return Ok(new BrewStatusResponse("Your refreshing iced coffee is ready", prepared));
         }
         else
         {

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Controllers/CoffeeMachineController.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Controllers/CoffeeMachineController.cs
@@ -44,21 +44,15 @@ public class CoffeeMachineController : ControllerBase
             throw;
         }
 
-        if (status == BrewStatus.ReadyHot)
+        var message = status switch
         {
-            var prepared = GetPreparedTimestamp(_dateTimeProvider.GetLocalNow());
-            return Ok(new BrewStatusResponse("Your piping hot coffee is ready", prepared));
-        }
-        else if (status == BrewStatus.ReadyIced)
-        {
-            var prepared = GetPreparedTimestamp(_dateTimeProvider.GetLocalNow());
-            return Ok(new BrewStatusResponse("Your refreshing iced coffee is ready", prepared));
-        }
-        else
-        {
-            // Interviewer note: The below exception subsequently gets handled in ErrorController.cs
-            throw new InvalidOperationException($"Unrecognized brew status: {status}");
-        }
+            BrewStatus.ReadyHot => "Your piping hot coffee is ready",
+            BrewStatus.ReadyIced => "Your refreshing iced coffee is ready",
+            _ => throw new InvalidOperationException($"Unrecognized brew status: {status}") // Interviewer note: The below exception subsequently gets handled in ErrorController.cs
+        };
+
+        var prepared = GetPreparedTimestamp(_dateTimeProvider.GetLocalNow());
+        return Ok(new BrewStatusResponse(message, prepared));
     }
 
     private string GetPreparedTimestamp(DateTime localNow)

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Controllers/CoffeeMachineController.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Controllers/CoffeeMachineController.cs
@@ -48,7 +48,7 @@ public class CoffeeMachineController : ControllerBase
         {
             BrewStatus.ReadyHot => "Your piping hot coffee is ready",
             BrewStatus.ReadyIced => "Your refreshing iced coffee is ready",
-            _ => throw new InvalidOperationException($"Unrecognized brew status: {status}") // Interviewer note: The below exception subsequently gets handled in ErrorController.cs
+            _ => throw new InvalidOperationException($"Unrecognized brew status: {status}") // Interviewer note: This exception subsequently gets handled in ErrorController.cs
         };
 
         var prepared = GetPreparedTimestamp(_dateTimeProvider.GetLocalNow());

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Filters/BrewStatusUnavailableFilter.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Filters/BrewStatusUnavailableFilter.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Caching.Memory;
+using RTech.CoffeeMachine.Api.BrewCoffee.Controllers;
+
+namespace RTech.CoffeeMachine.Api.BrewCoffee.Filters;
+
+public class BrewStatusUnavailableFilter : ActionFilterAttribute
+{
+    // Interviewer note: MemoryCache from Microsoft.Extensions.Caching.Abstractions is thread safe
+    private readonly IMemoryCache _cache;
+    public static readonly string CACHE_KEY_NUM_REQUESTS = $"{nameof(CoffeeMachineController.GetBrewStatus)}:numRequests";
+
+    public BrewStatusUnavailableFilter(IMemoryCache cache)
+    {
+        _cache = cache;
+        if (!_cache.TryGetValue<long>(CACHE_KEY_NUM_REQUESTS, out var _))
+        {
+            _cache.Set<long>(CACHE_KEY_NUM_REQUESTS, 0);
+        }
+    }
+
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        // Interviewer note: I'm assuming that on april 1st, every 5th request still returns 418
+        var numRequests = _cache.Get<long>(CACHE_KEY_NUM_REQUESTS);
+        numRequests++;
+        _cache.Set(CACHE_KEY_NUM_REQUESTS, numRequests);
+        if (numRequests % 5 == 0)
+        {
+            context.Result = new ObjectResult(null)
+            {
+                StatusCode = StatusCodes.Status503ServiceUnavailable
+            };
+        }
+
+        base.OnActionExecuting(context);
+    }
+}
+

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Filters/TeapotFilter.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Filters/TeapotFilter.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using RTech.CoffeeMachine.Api.BrewCoffee.Util;
+
+namespace RTech.CoffeeMachine.Api.BrewCoffee.Filters;
+
+public class TeapotFilter : ActionFilterAttribute
+{
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public TeapotFilter(IDateTimeProvider dateTimeProvider)
+    {
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public override void OnActionExecuting(ActionExecutingContext context)
+    {
+        // Interviewer note: I'm assuming that the april fools check uses local time (operating system time)
+        var localNow = _dateTimeProvider.GetLocalNow();
+        var isApril1st = localNow.Month == 4 && localNow.Day == 1;
+        if (isApril1st)
+        {
+            context.Result = new ObjectResult(null)
+            {
+                StatusCode = StatusCodes.Status418ImATeapot
+            };
+        }
+
+        base.OnActionExecuting(context);
+    }
+}
+

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Models/TemperatureResponse.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Models/TemperatureResponse.cs
@@ -1,0 +1,16 @@
+﻿using System.Text.Json.Serialization;
+
+namespace RTech.CoffeeMachine.Api.BrewCoffee.Models;
+
+public class TemperatureResponse
+{
+    [JsonPropertyName("current_weather")]
+    public CurrentWeather? Weather { get; set; }
+
+    public class CurrentWeather
+    {
+        public float Temperature { get; set; }
+    }
+}
+
+

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Util/BrewStatus.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Util/BrewStatus.cs
@@ -6,5 +6,6 @@
 public enum BrewStatus
 {
     None = 0,
-    Ready = 1
+    ReadyHot = 1,
+    ReadyIced = 2
 }

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Util/BrewStatusProvider.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Util/BrewStatusProvider.cs
@@ -2,5 +2,25 @@
 
 public class BrewStatusProvider : IBrewStatusProvider
 {
-    public BrewStatus GetBrewStatus() => BrewStatus.Ready;
+    private readonly IWeatherProxy _weatherProxy;
+
+    public BrewStatusProvider(IWeatherProxy weatherProxy)
+    {
+        _weatherProxy = weatherProxy;
+    }
+
+    public async Task<BrewStatus> GetBrewStatus()
+    {
+        var temp = await _weatherProxy.TryGetTemperature();
+        if (!temp.HasValue)
+        {
+            throw new InvalidOperationException("Temperature retrieval failed");
+        }
+
+        if (temp > 30)
+        {
+            return BrewStatus.ReadyIced;
+        }
+        return BrewStatus.ReadyHot;
+    }
 }

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Util/IBrewStatusProvider.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Util/IBrewStatusProvider.cs
@@ -5,5 +5,5 @@
 /// </summary>
 public interface IBrewStatusProvider
 {
-    BrewStatus GetBrewStatus();
+    Task<BrewStatus> GetBrewStatus();
 }

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Util/IWeatherProxy.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Util/IWeatherProxy.cs
@@ -1,0 +1,6 @@
+namespace RTech.CoffeeMachine.Api.BrewCoffee.Util;
+
+public interface IWeatherProxy
+{
+    Task<float?> TryGetTemperature();
+}

--- a/RTech.CoffeeMachine.Api/BrewCoffee/Util/WeatherProxy.cs
+++ b/RTech.CoffeeMachine.Api/BrewCoffee/Util/WeatherProxy.cs
@@ -1,0 +1,51 @@
+using RTech.CoffeeMachine.Api.BrewCoffee.Models;
+
+namespace RTech.CoffeeMachine.Api.BrewCoffee.Util;
+
+public class WeatherProxy : IWeatherProxy
+{
+    private readonly ILogger<WeatherProxy> _logger;
+    private readonly HttpClient _httpClient;
+    // Interviewer notes:
+    // * I'm choosing to use a const here, since theres nothing to change at run-time.
+    // * If the url had dynamic variables & had to change at run-time, i'd use UriBuilder or an equivalent to construct the url.
+    public const string WEATHER_URL = "/v1/forecast?latitude=-37.81&longitude=144.96&hourly=temperature_2m&current_weather=true";
+
+    public WeatherProxy(ILogger<WeatherProxy> logger, HttpClient httpClient)
+    {
+        _logger = logger;
+        _httpClient = httpClient;
+    }
+
+    /// <returns>
+    /// Temperature in metric, null if failed to retrieve data
+    /// </returns>
+    public async Task<float?> TryGetTemperature()
+    {
+        _logger.LogInformation("Retrieving temperature..");
+        try
+        {
+            // Interviewer notes:
+            // * i'm assuming hard-coded latitude longitude is permitted (i.e.: not accessing gps or server location geolocation at run-time)
+            // * this api uses the open-source https://open-meteo.com/
+            using (var response = await _httpClient.GetAsync(WEATHER_URL))
+            {
+                response.EnsureSuccessStatusCode();
+                var result = await response.Content.ReadFromJsonAsync<TemperatureResponse>();
+                var temp = result?.Weather?.Temperature;
+                if (!temp.HasValue)
+                {
+                    throw new InvalidOperationException("Weather provider data source did not return a temperature");
+                }
+
+                _logger.LogInformation($"Retrieved, temp={temp}");
+                return temp;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve temperature");
+            return null;
+        }
+    }
+}

--- a/RTech.CoffeeMachine.Api/Program.cs
+++ b/RTech.CoffeeMachine.Api/Program.cs
@@ -1,10 +1,25 @@
-﻿using RTech.CoffeeMachine.Api.BrewCoffee.Util;
+﻿using RTech.CoffeeMachine.Api.BrewCoffee.Filters;
+using RTech.CoffeeMachine.Api.BrewCoffee.Util;
 
 var builder = WebApplication.CreateBuilder(args);
 var services = builder.Services;
 services.AddMemoryCache();
 services.AddSingleton<IBrewStatusProvider, BrewStatusProvider>();
 services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
+services.AddSingleton<TeapotFilter>();
+services.AddSingleton<BrewStatusUnavailableFilter>();
+
+services.AddHttpClient<IWeatherProxy, WeatherProxy>(client =>
+{
+    var weatherProviderBaseAddress = builder.Configuration.GetValue<string>("WeatherProviderBaseAddress");
+    if (string.IsNullOrWhiteSpace(weatherProviderBaseAddress))
+    {
+        throw new InvalidOperationException("Missing config for WeatherProviderBaseAddress");
+    }
+
+    client.BaseAddress = new Uri(weatherProviderBaseAddress);
+}).SetHandlerLifetime(Timeout.InfiniteTimeSpan);    // Weather API does not require auth (e.g.: no oauth token expiry)
+
 services.AddControllers();
 
 var app = builder.Build();

--- a/RTech.CoffeeMachine.Api/RTech.CoffeeMachine.Api.csproj
+++ b/RTech.CoffeeMachine.Api/RTech.CoffeeMachine.Api.csproj
@@ -18,12 +18,14 @@
     <None Remove="BrewCoffee\Models\" />
     <None Remove="BrewCoffee\Util\" />
     <None Remove="Microsoft.Extensions.Caching.Abstractions" />
+    <None Remove="BrewCoffee\Filters\" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="BrewCoffee\" />
     <Folder Include="BrewCoffee\Controllers\" />
     <Folder Include="BrewCoffee\Models\" />
     <Folder Include="BrewCoffee\Util\" />
+    <Folder Include="BrewCoffee\Filters\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />

--- a/RTech.CoffeeMachine.Api/appsettings.Development.json
+++ b/RTech.CoffeeMachine.Api/appsettings.Development.json
@@ -4,6 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "WeatherProviderBaseAddress": "https://api.open-meteo.com"
 }
-

--- a/RTech.CoffeeMachine.Api/appsettings.json
+++ b/RTech.CoffeeMachine.Api/appsettings.json
@@ -5,6 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "WeatherProviderBaseAddress": "https://api.open-meteo.com"
 }
-


### PR DESCRIPTION
- Added failing tests first (tdd), then made them pass
- Add Weather proxy
- Add logic to check if > 30 degrees celsius
- Add new "ReadyIced" member to BrewStatus enum
- Add integration tests to cover new "iced" coffee message (inc. nuget package "RichardSzalay.MockHttp" to mock http cleanly)
- Add new app setting "WeatherProviderBaseAddress"
- Refactor teapot & "service unavailable" logic into action filters
- Update brew coffee endpoint to return "bad gateway" when cant get temperature from weather provider
